### PR TITLE
fix: clean-machine install packaging gaps and README accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pip install -e ".[dev]"
 python _app_entry.py
 ```
 
-> **GPU users:** use `.venv-gpu` with `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118` before the editable install.
+> **GPU users:** Install CUDA torch into the same venv before the editable install: `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118`
 
 ### First use
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ dependencies = [
     "torch>=2.0.0",
     "pydub>=0.25.0",
     "typing-extensions>=4.0.0",
+    "psutil>=5.9.0",
+    "huggingface_hub>=0.20.0",
 ]
 
 [project.optional-dependencies]
@@ -82,9 +84,6 @@ voiceflow-daily-learning = "voiceflow.ai.daily_learning:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/voiceflow"]
-
-[tool.hatch.build]
-directory = "src"
 
 [tool.hatch.build.targets.sdist]
 include = [
@@ -151,29 +150,6 @@ module = [
     "pyaudio.*",
 ]
 ignore_missing_imports = true
-
-# Pytest configuration
-[tool.pytest.ini_options]
-testpaths = ["tests/runtime"]
-python_files = ["test_*.py", "*_test.py"]
-python_classes = ["Test*"]
-python_functions = ["test_*"]
-addopts = [
-    "--strict-markers",
-    "--strict-config",
-]
-markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "unit: marks tests as unit tests",
-    "integration: marks tests as integration tests",
-    "contract: marks tests as contract tests",
-    "stability: marks tests as stability tests",
-    "performance: marks tests as performance tests",
-    "e2e: marks tests as end-to-end tests",
-    "windows: marks tests as windows-specific",
-    "audio: marks tests requiring audio devices",
-    "gui: marks tests requiring GUI components",
-]
 
 # Coverage configuration
 [tool.coverage.run]


### PR DESCRIPTION
## Summary

- **Add `psutil` and `huggingface_hub` to declared deps** — `psutil` is a hard dependency (direct import in `process_monitor.py`, singleton detection in `cli_enhanced.py`) that lived only in `scripts/setup/requirements_windows.txt`, not the installable package metadata. A fresh `pip install -e .` on a clean machine would silently miss it. `huggingface_hub` is used in the setup wizard download flow; declared here explicitly even though it arrives transitively via `faster-whisper`.

- **Remove `[tool.hatch.build] directory = "src"`** — This directed built wheel/sdist artifacts into the source tree instead of `dist/`. Harmless for editable installs but would break `python -m build`.

- **Remove duplicate `[tool.pytest.ini_options]` from `pyproject.toml`** — `pytest.ini` is the canonical, more complete config. Having both caused pytest to emit a confusing warning on every run.

- **Clarify README GPU install note** — Replaced the misleading `.venv-gpu` reference (a developer venv name) with a plain instruction to install CUDA torch into the same venv before the editable install.

## Test plan

- [x] All 126 tests pass
- [x] Setup wizard logic verified for no-CUDA / no-model / first-time config scenarios
- [x] VoiceFlow singleton detection confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)